### PR TITLE
Fix SAND8 params setup when video resolution matches default one

### DIFF
--- a/drm_mmal.c
+++ b/drm_mmal.c
@@ -1282,6 +1282,10 @@ usage:
    isp->output[0]->userdata = (void *)&context;
    mmal_format_full_copy(isp->output[0]->format, isp->input[0]->format);
    isp->output[0]->format->encoding = fmt;
+   if (fmt == MMAL_ENCODING_YUVUV128) {
+         isp->output[0]->format->flags |= MMAL_ES_FORMAT_FLAG_COL_FMTS_WIDTH_IS_COL_STRIDE;
+         isp->output[0]->format->es->video.width = get_sand_column_pitch(isp->output[0]->format->es->video.height);
+   }
 
    status = mmal_port_format_commit(isp->output[0]);
    CHECK_STATUS(status, "failed to set ISP output format");
@@ -1374,7 +1378,7 @@ usage:
                isp->output[0]->buffer_size = isp->output[0]->buffer_size_min;
 
                if (fmt == MMAL_ENCODING_YUVUV128) {
-                  isp->output[0]->format->flags = MMAL_ES_FORMAT_FLAG_COL_FMTS_WIDTH_IS_COL_STRIDE;
+                  isp->output[0]->format->flags |= MMAL_ES_FORMAT_FLAG_COL_FMTS_WIDTH_IS_COL_STRIDE;
                   isp->output[0]->format->es->video.width = get_sand_column_pitch(isp->output[0]->format->es->video.height);
                }
 


### PR DESCRIPTION
This initial setup is already available at https://github.com/6by9/drm_mmal/commit/9661f664f6dcae8e9762850414087dc7ae822e4b#diff-026db9c2d656ec3e2ca03ddaed6d188f25b61790cebc954241ea97b15166caceR823

Missing this was the cause of having incorrect modifiers when resolution matches 720p